### PR TITLE
LDAP-Plugin hinzugefügt

### DIFF
--- a/qa-include/pages/login.php
+++ b/qa-include/pages/login.php
@@ -58,6 +58,8 @@ if (qa_clicked('dologin') && (strlen($inemailhandle) || strlen($inpassword))) {
 		require_once QA_INCLUDE_DIR . 'db/users.php';
 		require_once QA_INCLUDE_DIR . 'db/selects.php';
 
+		require_once QA_INCLUDE_DIR.'../qa-plugin/qa-ldap-login/qa-ldap-process.php';
+
 		if (!qa_check_form_security_code('login', qa_post_text('code'))) {
 			$pageerror = qa_lang_html('misc/form_security_again');
 		}

--- a/qa-plugin/qa-ldap-login/ActiveDirectoryLDAPServer.php
+++ b/qa-plugin/qa-ldap-login/ActiveDirectoryLDAPServer.php
@@ -1,0 +1,69 @@
+<?php
+/* This class represents behavior and properties
+/* for a Active Directory server with LDAP interfacing enabled.
+/* Tested against a Windows 2008R2 domain AD master.
+ */
+
+class ActiveDirectoryLDAPServer extends LDAPServer {
+  private $dn;
+  private $authenticatedUser;
+
+  public function bindToLDAP($user,$pass) {
+    $filter = "(".qa_opt('ldap_authentication_attribute')."=".$user.")";
+
+    // Check if it authenticates the service account
+    error_reporting(E_ALL^ E_WARNING);
+    if(!qa_opt('ldap_login_ad_pwd')) {
+        @$bind_service_account = ldap_bind($this->con);
+    } else {
+        @$bind_service_account = ldap_bind($this->con,qa_opt('ldap_login_ad_bind'), qa_opt('ldap_login_ad_pwd'));
+    }
+
+    if($bind_service_account) {
+      $attributes = array('dn');
+      $search = ldap_search($this->con, qa_opt('ldap_login_ad_basedn'), $filter, $attributes);
+      $data = ldap_get_entries($this->con, $search);
+    } else {
+      return false;
+    }
+
+    // if the user is found, try to authenticate with his DN and password entered
+    if (isset($data[0])) {
+      $this->dn = $data[0]['dn'];
+      @$bind_user = ldap_bind($this->con, $this->dn, $pass);
+    } else {
+      return false;
+    }
+
+    error_reporting(E_ALL);
+
+    //we have to preserve the username entered if auth was succesfull
+    if($bind_user) {
+      $this->authenticatedUser=$user;
+      return($bind_user);
+    }
+
+    return false;
+  }
+
+  public function getUserAttributes() {
+    $fname_tag = qa_opt('ldap_login_fname');
+    $sname_tag = qa_opt('ldap_login_sname');
+    $mail_tag = qa_opt('ldap_login_mail');
+
+    $filter = qa_opt('ldap_login_filter');
+    $attributes = array('dn', $fname_tag, $sname_tag, $mail_tag);
+
+    // The DN is known so just use it to read attributes
+    $read = ldap_read($this->con, $this->dn, $filter, $attributes);
+    $data = ldap_get_entries($this->con, $read);
+
+    $fname = $data[0][strtolower($fname_tag)][0];
+    $sname = $data[0][strtolower($sname_tag)][0];
+    $mail  = $data[0][strtolower($mail_tag)][0];
+
+    return array( $fname, $sname, $mail, $this->authenticatedUser);
+  }
+}
+
+?>

--- a/qa-plugin/qa-ldap-login/GenericLDAPServer.php
+++ b/qa-plugin/qa-ldap-login/GenericLDAPServer.php
@@ -1,0 +1,53 @@
+<?php
+/* This class represents behavior and properties
+/* for a generic LDAP server.
+/* Tested against OpenLDAP.
+*/
+
+class GenericLDAPServer extends LDAPServer {
+  private $dn;
+  private $authenticatedUser;
+
+  public function bindToLDAP($user,$pass) {
+    $ldap_search_strings = explode('/', qa_opt('ldap_login_generic_search'));
+
+    foreach ($ldap_search_strings as &$search_post) {
+      // check whether the search string contains USERNAME
+      if ( strpos($search_post, 'USERNAME') !== false ) {
+        $this->dn = str_replace("USERNAME", $user, $search_post);
+        // Check if it authenticates
+        error_reporting(E_ALL^ E_WARNING);
+        $bind = ldap_bind($this->con,$this->dn, $pass);
+        error_reporting(E_ALL);
+
+        //we have to preserve the username entered if auth was succesfull
+        if($bind) {
+          $this->authenticatedUser = $user;
+          return $bind;
+        }
+      }
+    }
+    return false;
+  }
+
+  public function getUserAttributes() {
+    $fname_tag = qa_opt('ldap_login_fname');
+    $sname_tag = qa_opt('ldap_login_sname');
+    $mail_tag = qa_opt('ldap_login_mail');
+
+    // Run query to determine user's name
+    $filter = qa_opt('ldap_login_filter');
+    $attributes = array($fname_tag, $sname_tag, $mail_tag);
+
+    $search = ldap_search($this->con, $this->dn, $filter, $attributes);
+    $data = ldap_get_entries($this->con, $search);
+
+    $fname = $data[0][strtolower($fname_tag)][0];
+    $sname = $data[0][strtolower($sname_tag)][0];
+    $mail  = $data[0][strtolower($mail_tag)][0];
+
+    return array( $fname, $sname, $mail, $this->authenticatedUser);
+  }
+}
+
+?>

--- a/qa-plugin/qa-ldap-login/LDAPServer.php
+++ b/qa-plugin/qa-ldap-login/LDAPServer.php
@@ -1,0 +1,30 @@
+<?php
+
+class LDAPServer {
+  protected $con;
+  protected $lastError;
+
+  public function connectWithServer() {
+    $ldap_host = qa_opt('ldap_login_hostname');
+    // Establish link with LDAP server
+    $this->con = ldap_connect($ldap_host, qa_opt('ldap_login_port')) or die ("Could not connect to $ldap_host host.");
+    if (!is_resource($this->con)) trigger_error("Unable to connect to hostname", E_USER_WARNING);
+    ldap_set_option($this->con, LDAP_OPT_PROTOCOL_VERSION, 3);
+    ldap_set_option($this->con, LDAP_OPT_REFERRALS, 0);
+  }
+
+  public function bindToLDAP($user,$pass) {}
+
+  public function getUserAttributes() {}
+
+  public function closeServerConnection() {
+    $this->lastError = ldap_errno($this->con);
+    ldap_close($this->con);
+  }
+
+  public function showErrors() {
+    return $this->lastError;
+  }
+}
+
+?>

--- a/qa-plugin/qa-ldap-login/README.md
+++ b/qa-plugin/qa-ldap-login/README.md
@@ -1,0 +1,38 @@
+# LDAP login
+
+## README
+
+qa-ldap-login is an LDAP authentication mechanism for
+Question2Answer. In it's current form, it is intended to
+replace/augment the existing Q2A login form. The script will first
+check user credentials against LDAP and can fall back to the internal
+authentication if that fails. If a user exists in LDAP but not Q2A,
+the script will create a new user account for the individual.
+
+## PREREQS
+
+In order for PHP's built-in LDAP functionality to work correctly, your
+web server must be properly configured. In CentOS, this means openldap
+must be installed, and any certificates necessary to authenticate with
+LDAP specified in the openldap configuration.
+
+## INSTALL
+
+To install the plugin:
+
+1. Add the qa-ldap-login directory with plugin files to the qa-plugin directory for your Q2A install.
+
+2. Insert the following line of code above the if statement at line 61 of qa-include/pages/login.php
+
+	require_once QA_INCLUDE_DIR.'../qa-plugin/qa-ldap-login/qa-ldap-process.php';
+
+3. Change the options for the plugin in the administrator interface.
+
+4. If your LDAP settings are configured correctly, that should be it!
+
+## DEBUG
+
+In case it doesn't work try commenting out
+`error_reporting(E_ALL^E_WARNING);` in GenericLDAPServer.php and/or
+ActiveDirectoryLDAPServer.php.  This will enable printing warnings
+from

--- a/qa-plugin/qa-ldap-login/ldap-login-admin-form.php
+++ b/qa-plugin/qa-ldap-login/ldap-login-admin-form.php
@@ -1,0 +1,203 @@
+<?php
+
+/*
+/* This class represents administator settings
+/* for the LDAP plugin.
+*/
+
+class ldap_login_admin_form {
+  function option_default($option)   {
+    if ($option=='ldap_login_hostname')
+      return 'ldap://localhost';
+    if ($option=='ldap_login_port')
+      return 389;
+
+    if ($option=='ldap_login_filter')
+      return '(objectClass=*)';
+    if ($option=='ldap_login_fname')
+      return 'givenname';
+    if ($option=='ldap_login_sname')
+      return 'sn';
+    if ($option=='ldap_login_mail')
+      return 'mail';
+
+    if ($option=='ldap_login_ad')
+      return true;
+    if ($option=='ldap_login_ad_bind')
+      return 'CN=serviceaccount,CN=Managed Service Accounts,DC=contoso,DC=local';
+    if ($option=='ldap_login_ad_pwd')
+      return '12345678';
+    if ($option=='ldap_login_ad_basedn')
+      return 'OU=Users,DC=contoso,DC=local';
+
+    if ($option=='ldap_login_generic_search')
+      return 'uid=USERNAME,OU=people,DC=company,DC=local/uid=USERNAME,OU=people3,DC=company,DC=local';
+
+    if ($option=='ldap_authentication_attribute')
+      return 'sAMAccountName'; // The legacy logon name in a Windows AD environment
+
+    if ($option=='ldap_login_allow_normal')
+      return true;
+    if ($option=='ldap_login_allow_registration')
+      return false;
+    return null;
+  }
+
+  function admin_form(&$qa_content) {
+    $saved=false;
+
+    if (qa_clicked('ldap_login_save_button')) {
+      qa_opt('ldap_login_hostname', qa_post_text('ldap_login_hostname_field'));
+      qa_opt('ldap_login_port', (int) qa_post_text('ldap_login_port_field'));
+
+      qa_opt('ldap_login_filter', qa_post_text('ldap_login_filter_field'));
+      qa_opt('ldap_login_fname', qa_post_text('ldap_login_fname_field'));
+      qa_opt('ldap_login_sname', qa_post_text('ldap_login_sname_field'));
+      qa_opt('ldap_login_mail', qa_post_text('ldap_login_mail_field'));
+
+      qa_opt('ldap_login_ad', (bool) qa_post_text('ldap_login_ad_field'));
+      qa_opt('ldap_login_ad_bind', qa_post_text('ldap_login_ad_bind_field'));
+      qa_opt('ldap_login_ad_pwd', qa_post_text('ldap_login_ad_pwd_field'));
+      qa_opt('ldap_login_ad_basedn', qa_post_text('ldap_login_ad_basedn_field'));
+      qa_opt('ldap_login_generic_search', qa_post_text('ldap_login_generic_search_field'));
+
+      qa_opt('ldap_authentication_attribute', qa_post_text('ldap_authentication_attribute_field'));
+
+      qa_opt('ldap_login_allow_normal', (bool) qa_post_text('ldap_login_allow_normal_field'));
+      qa_opt('ldap_login_allow_registration', (bool) qa_post_text('ldap_login_allow_registration_field'));
+
+      $saved=true;
+    }
+
+    qa_set_display_rules($qa_content, array(
+      'ldap_login_allow_registration_display' => 'ldap_login_allow_normal_field',
+      'ldap_login_ad_bind_display' => 'ldap_login_ad_field',
+      'ldap_login_ad_pwd_display' => 'ldap_login_ad_field',
+      'ldap_login_ad_basedn_display' => 'ldap_login_ad_field',
+      'ldap_login_generic_search_display' => '!ldap_login_ad_field',
+    ));
+
+    return array(
+      'ok' => $saved ? 'LDAP settings saved' : null,
+
+      'fields' => array(
+        array(
+          'label' => 'Hostname for LDAP Server (ldap://x.y.z for non-SSL, ldaps://x.y.x for SSL)',
+          'type' => 'text',
+          'value' => qa_opt('ldap_login_hostname'),
+          'tags' => 'name="ldap_login_hostname_field"',
+        ),
+
+        array(
+          'label' => 'Port for LDAP Server (389 for non-SSL, 636 for SSL)',
+          'type' => 'number',
+          'value' => qa_opt('ldap_login_port'),
+          'tags' => 'name="ldap_login_port_field"',
+        ),
+
+        array(
+          'label' => 'LDAP filter',
+          'type' => 'text',
+          'value' => qa_opt('ldap_login_filter'),
+          'tags' => 'name="ldap_login_filter_field"',
+        ),
+
+        array(
+          'label' => 'LDAP Firstname field',
+          'type' => 'text',
+          'value' => qa_opt('ldap_login_fname'),
+          'tags' => 'name="ldap_login_fname_field"',
+        ),
+
+        array(
+          'label' => 'LDAP Surname field',
+          'type' => 'text',
+          'value' => qa_opt('ldap_login_sname'),
+          'tags' => 'name="ldap_login_sname_field"',
+        ),
+
+        array(
+          'label' => 'LDAP Email field',
+          'type' => 'text',
+          'value' => qa_opt('ldap_login_mail'),
+          'tags' => 'name="ldap_login_mail_field"',
+        ),
+
+        array(
+          'label' => 'Use Active Directory Server (unchecked: use generic LDAP)',
+          'type' => 'checkbox',
+          'value' => qa_opt('ldap_login_ad'),
+          'tags' => 'name="ldap_login_ad_field" id="ldap_login_ad_field"',
+        ),
+
+        array(
+          'id' => 'ldap_login_ad_bind_display',
+          'label' => 'Binding account for AD',
+          'type' => 'text',
+          'value' => qa_opt('ldap_login_ad_bind'),
+          'tags' => 'name="ldap_login_ad_bind_field"',
+        ),
+
+        array(
+          'id' => 'ldap_login_ad_pwd_display',
+          'label' => 'Password for AD binging accout',
+          'type' => 'text',
+          'value' => qa_opt('ldap_login_ad_pwd'),
+          'tags' => 'name="ldap_login_ad_pwd_field"',
+        ),
+
+        array(
+          'id' => 'ldap_login_ad_basedn_display',
+          'label' => 'Base DN for AD (Usually default user OU in the Active Directory, otherwise top of the tree)',
+          'type' => 'text',
+          'value' => qa_opt('ldap_login_ad_basedn'),
+          'tags' => 'name="ldap_login_ad_basedn_field"',
+        ),
+
+        array(
+          'id' => 'ldap_login_generic_search_display',
+          'label' => 'Generic LDAP search strings (at login the plugin will replace USERNAME with the user\'s username. Separate each query string with \'/\')',
+          'type' => 'text',
+          'value' => qa_opt('ldap_login_generic_search'),
+          'tags' => 'name="ldap_login_generic_search_field"',
+        ),
+
+        array(
+          'id' => 'ldap_authentication_attribute_display',
+          'label' => 'Generic LDAP search authenticate attribute (e.g. sAMAccountName, sn, mail, givenName etc.)',
+          'type' => 'text',
+          'value' => qa_opt('ldap_authentication_attribute'),
+          'tags' => 'name="ldap_authentication_attribute_field"',
+        ),
+
+
+        array(
+          'label' => 'Allow normal logins as a fallback to LDAP',
+          'type' => 'checkbox',
+          'value' => qa_opt('ldap_login_allow_normal'),
+          'tags' => 'name="ldap_login_allow_normal_field" id="ldap_login_allow_normal_field"',
+        ),
+
+        array(
+          'id' => 'ldap_login_allow_registration_display',
+          'label' => 'Allow registration when normal logins are allowed',
+          'type' => 'checkbox',
+          'value' => qa_opt('ldap_login_allow_registration'),
+          'tags' => 'name="ldap_login_allow_registration_field"',
+        ),
+      ),
+
+      'buttons' => array(
+        array(
+          'label' => 'Save Changes',
+          'tags' => 'name="ldap_login_save_button"',
+        ),
+      ),
+    );
+  }
+
+}
+
+/*
+  Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-plugin/qa-ldap-login/ldap-login-layer.php
+++ b/qa-plugin/qa-ldap-login/ldap-login-layer.php
@@ -1,0 +1,15 @@
+<?php
+
+  class qa_html_theme_layer extends qa_html_theme_base {
+  
+    function nav_list($navigation, $navtype, $level=null) {
+      // remove the registration link unless normal login AND allow registration booleans are set in options
+      if(!(qa_opt('ldap_login_allow_normal') && qa_opt('ldap_login_allow_registration'))) {
+        unset($navigation['register']);
+      }
+
+      qa_html_theme_base::nav_list($navigation, $navtype, $level);
+    } // end function nav_list
+  }
+
+?>

--- a/qa-plugin/qa-ldap-login/ldap-login-logout-page.php
+++ b/qa-plugin/qa-ldap-login/ldap-login-logout-page.php
@@ -1,0 +1,54 @@
+<?php
+
+class ldap_logout_process {
+  var $directory;
+  var $urltoroot;
+
+  function load_module($directory, $urltoroot) {
+    $this->directory=$directory;
+    $this->urltoroot=$urltoroot;
+  } // end function load_module
+
+  function suggest_requests() {
+    return array(
+      array(
+        'title' => 'Logout',
+        'request' => 'auth/logout',
+        'nav' => 'null',
+      ),
+    );
+  } // end function suggest_requests
+
+  function match_request($request) {
+    if ($request=='auth/logout')
+      return true;
+
+    return false;
+  } // end function match_request
+
+  function process_request($request) {
+    require_once QA_INCLUDE_DIR."qa-base.php";
+
+    $expire = 14*24*60*60;
+    if(isset($_SESSION['logout_url'])) {
+      $tourl = $_SESSION['logout_url'];
+    } else {
+      $tourl = false;
+    }
+    
+    if(isset($_COOKIE["qa-login_fname"])) {
+      setcookie("qa-login_fname", '1', time()-$expire, '/');
+      setcookie("qa-login_lname", '1', time()-$expire, '/');
+      setcookie("qa-login_email", '1', time()-$expire, '/');
+    }
+    session_destroy();
+    if (!$tourl) {
+      qa_redirect('logout');
+    } else {
+      header('Location: '.$tourl);
+    }
+    return null;
+  } // end function process_request
+
+}
+?>

--- a/qa-plugin/qa-ldap-login/ldap-login.php
+++ b/qa-plugin/qa-ldap-login/ldap-login.php
@@ -1,0 +1,53 @@
+<?php
+
+class ldap_login {
+  function load_module($directory, $urltoroot) {
+    $this->directory=$directory;
+    $this->urltoroot=$urltoroot;
+  } // end function load_module
+
+  // check_login checks to see if user is already logged in by looking for
+  // a cookie or session variable (dependent on 'remember me' setting
+  function check_login() {
+    if(!isset($_COOKIE["qa-login_fname"]) && !isset($_SESSION["qa-login_fname"])) {
+      return false;
+    } else {
+      if(isset($_COOKIE["qa-login_fname"])) {
+        $fname = $_COOKIE["qa-login_fname"];
+        $lname = $_COOKIE["qa-login_lname"];
+        $email = $_COOKIE["qa-login_email"];
+        $username = $_COOKIE["qa-login_user"];
+      } else {
+        $fname = $_SESSION["qa-login_fname"];
+        $lname = $_SESSION["qa-login_lname"];
+        $email = $_SESSION["qa-login_email"];
+        $username = $_SESSION["qa-login_user"];
+      }
+      $source = 'ldap';
+      $identifier = $email;
+
+      $fields['email'] = $email;
+      $fields['confirmed'] = true;
+      $fields['handle'] = $username;
+      $fields['name'] = $fname . " " . $lname;
+      qa_log_in_external_user($source,$identifier,$fields);
+    }
+  } // end function check_login
+
+  function match_source($source) {
+    return $source=='ldap';
+  }
+
+  function login_html($tourl, $context) {} 
+
+  function logout_html ($tourl) {
+    require_once QA_INCLUDE_DIR."qa-base.php";
+
+    $_SESSION['logout_url'] = $tourl;
+    $logout_url = qa_path('auth/logout', null, qa_path_to_root());
+    echo('<a href="'.$logout_url.'">'.qa_lang_html('main/nav_logout').'</a>');
+  } // end function logout_html
+
+} // end class ldap_login
+
+?>

--- a/qa-plugin/qa-ldap-login/qa-ldap-process.php
+++ b/qa-plugin/qa-ldap-login/qa-ldap-process.php
@@ -1,0 +1,99 @@
+<?php
+  /* This script grabs the user/pass combo directly
+   * from the Question2Answer login page.
+   * It uses a service account to find
+   * the user in the ldap database.
+   * When found the user/pass combo is checked against the
+   * LDAP authentication source. Following
+   * this check, it either creates a SESSION array or
+   * a cookie that can be checked by the ldap-login
+   * module's check_login function, and bypasses the
+   * internal QA auth mechanism by redirecting back to
+   * the login page.
+  */
+
+  require_once QA_INCLUDE_DIR."qa-base.php";
+  require_once QA_INCLUDE_DIR."../qa-plugin/qa-ldap-login/LDAPServer.php";
+  require_once QA_INCLUDE_DIR."../qa-plugin/qa-ldap-login/ActiveDirectoryLDAPServer.php";
+  require_once QA_INCLUDE_DIR."../qa-plugin/qa-ldap-login/GenericLDAPServer.php";
+
+  global $ldapserver;
+
+  function ldap_process ($user,$pass) {
+    global $ldapserver;
+
+    // Check ig user or pass is empty
+    if ( '' == $user || '' ==  $pass ) {
+      return false;
+    }
+
+    if (qa_opt('ldap_login_ad')) {
+    	$ldapserver = new ActiveDirectoryLDAPServer();
+    } else {
+      $ldapserver = new GenericLDAPServer();
+    }
+
+    $ldapserver->connectWithServer();
+
+    if ($ldapserver->bindToLDAP($user,$pass)) {
+      $data = $ldapserver->getUserAttributes();
+      return $data;
+    }
+
+    $ldapserver->closeServerConnection();
+    return false;
+  }
+
+  function isEmpty($attr) {
+    if($attr == '' || preg_match("/^[[:space:]]+$/", $attr)) {
+      return true;
+    }
+    return false;
+  }
+
+  $expire = 14*24*60*60;
+
+  if (!isEmpty($inemailhandle)) {
+    if (!isEmpty($inpassword)) {
+      $name = ldap_process($inemailhandle,$inpassword);
+      if ($name) {
+        // Set name variables based on results from LDAP
+        $fname = $name[0];
+        $lname = $name[1];
+        $email = $name[2];
+        $user = $name[3];
+
+        // Do not login or create account if mail value is NULL
+        if ( '' == $email ){
+          // FIXME somehow print a message
+          qa_redirect('login');
+          exit();
+        }
+
+        if($inremember == '1') {
+          setcookie("qa-login_lname", $lname, time() + $expire, '/');
+          setcookie("qa-login_fname", $fname, time() + $expire, '/');
+          setcookie("qa-login_email", $email, time() + $expire, '/');
+          setcookie("qa-login_user", $user, time() + $expire, '/');
+        } else {
+          $_SESSION["qa-login_lname"] = $lname;
+          $_SESSION["qa-login_fname"] = $fname;
+          $_SESSION["qa-login_email"] = $email;
+          $_SESSION["qa-login_user"] = $user;
+        }
+        $topath=qa_get('to');
+        if (isset($topath))
+          qa_redirect_raw(qa_path_to_root().$topath); // path already provided as URL fragment
+        else
+          qa_redirect('');
+        exit();
+      } else {
+        if(!qa_opt('ldap_login_allow_normal')) {
+          // FIXME somehow print a message
+          qa_redirect('login');
+          exit();
+        }
+      }
+    }
+  }
+?>

--- a/qa-plugin/qa-ldap-login/qa-plugin.php
+++ b/qa-plugin/qa-ldap-login/qa-plugin.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+  Plugin Name: LDAP-Login
+  Plugin Description: Allows ldap authentication within Q2A
+  Plugin URI: https://github.com/zakkak/qa-ldap-login
+  Plugin Update Check URI: https://github.com/zakkak/qa-ldap-login/raw/master/qa-plugin.php
+  Plugin Version: 0.4
+  Plugin Date: 2013-10-05
+  Plugin Author: Karl Bitz, Foivos S. Zakkak, Peter Edwards
+  Plugin License: Free
+  Plugin Minimum Question2Answer Version: 1.4
+*/
+
+error_reporting(E_ALL);
+
+// don't allow this page to be requested directly from browser
+if (!defined('QA_VERSION')) {
+	header('Location: ../../');
+	exit;
+}
+
+qa_register_plugin_module('login','ldap-login.php','ldap_login','LDAP Login');
+qa_register_plugin_layer('ldap-login-layer.php','LDAP Login Layer');
+qa_register_plugin_module('page','ldap-login-logout-page.php','ldap_logout_process','LDAP Logout Process');
+qa_register_plugin_module('module', 'ldap-login-admin-form.php', 'ldap_login_admin_form', 'LDAP Login');
+
+/*
+  Omit PHP closing tag to help avoid accidental output
+*/


### PR DESCRIPTION
Hallo Nick!

Hier also das LDAP-Plugin. Wenn folgende Vorbedingung erfüllt ist, sollte man das Plugin nach dem Start in der Admin-Konsole von q2a konfigurieren können:

> In order for PHP's built-in LDAP functionality to work correctly, your web server must be properly configured. In CentOS, this means openldap must be installed, and any certificates necessary to authenticate with LDAP specified in the openldap configuration.

Ich hoffe, das lässt sich im Pod leicht konfigurieren? Mit einem Docker-Image könnte ich es dir noch sagen, so eher schwierig 😁 